### PR TITLE
Implement send and sync for FpPrint

### DIFF
--- a/src/device/device_sync.rs
+++ b/src/device/device_sync.rs
@@ -183,7 +183,7 @@ impl FpDevice {
     pub fn verify_sync<T>(
         &self,
         enrolled_print: &FpPrint,
-        cancellable: Option<gio::Cancellable>,
+        cancellable: Option<&Cancellable>,
         match_cb: Option<FpMatchCb<T>>,
         match_data: Option<T>,
         print: Option<&mut FpPrint>, // TODO: Handle initialized

--- a/src/print.rs
+++ b/src/print.rs
@@ -16,7 +16,8 @@ wrapper! {
         type_ => || libfprint_sys::fp_print_get_type() as usize,
     }
 }
-
+unsafe impl Send for FpPrint {}
+unsafe impl Sync for FpPrint {}
 impl FpPrint {
     /// Create a new `FpPrint`. This is only useful to prepare an enrollment of a new print using `FpDevice::enroll_sync`.
     /// For this you should first create a new print, fill in the relevant metadata, and then start the enrollment


### PR DESCRIPTION
Implementing the Send and Sync trait for FpPrint struct. I had to do this since it was causing issues with integrations on async related stuff.